### PR TITLE
feat(schema-bootstrap): session orchestrator with distributed lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .DS_Store
+.test-results/
+tests/.phpunit.cache/
 **/.phpdoc
 **/vendor
 **/docs

--- a/bin/y2-schema-bootstrap.php
+++ b/bin/y2-schema-bootstrap.php
@@ -1,0 +1,58 @@
+#!/usr/bin/env php
+<?php declare(strict_types=1);
+
+/**
+ * YeAPF2 schema session bootstrap CLI.
+ *
+ * Usage:
+ *   php bin/y2-schema-bootstrap.php --app-root=/path/to/application [--force]
+ */
+
+$root = dirname(__DIR__);
+require_once $root . '/src/yeapf-core.php';
+
+$options = getopt('', ['app-root:', 'force']);
+$appRoot = $options['app-root'] ?? '';
+$force = array_key_exists('force', $options);
+
+if ($appRoot === '' || !is_dir($appRoot)) {
+    fwrite(STDERR, "Usage: php bin/y2-schema-bootstrap.php --app-root=/path/to/app [--force]\n");
+    exit(1);
+}
+
+$appRoot = realpath($appRoot) ?: $appRoot;
+
+$entryScript = is_file($appRoot . '/public/index.php')
+    ? $appRoot . '/public/index.php'
+    : $appRoot . '/index.php';
+$_SERVER['SCRIPT_FILENAME'] = $entryScript;
+
+\YeAPF\YeAPFConfig::open();
+
+$redis = null;
+try {
+    $redis = new \YeAPF\Connection\DB\RedisConnection();
+} catch (\Throwable) {
+    // Redis optional for CLI when only FS lock is used.
+}
+
+$context = new \YeAPF\Connection\PersistenceContext($redis, null);
+$orchestrator = \YeAPF\SchemaBootstrap\SchemaSessionOrchestrator::factory($appRoot, $context, $redis);
+
+$main = \YeAPF\Connection\DB\CreateMainPDOConnection();
+$conn = null;
+$main->popConnection($conn);
+
+try {
+    $hash = $orchestrator->run($context, $conn, $force);
+    fwrite(STDOUT, "Schema bootstrap completed. schemaHash={$hash}\n");
+    exit(0);
+} catch (\YeAPF\SchemaBootstrap\SchemaBootstrappedException $e) {
+    fwrite(STDERR, 'Bootstrap blocked: ' . $e->getMessage() . "\n");
+    exit(2);
+} catch (\Throwable $e) {
+    fwrite(STDERR, 'Bootstrap failed: ' . $e->getMessage() . "\n");
+    exit(1);
+} finally {
+    $main->pushConnection($conn);
+}

--- a/src/database/schema-bootstrap/DocumentModelManifest.php
+++ b/src/database/schema-bootstrap/DocumentModelManifest.php
@@ -1,0 +1,75 @@
+<?php declare(strict_types=1);
+
+namespace YeAPF\SchemaBootstrap;
+
+final class DocumentModelManifest
+{
+    /**
+     * @return list<array{
+     *   table:string,
+     *   file:string,
+     *   constraints:array<string,array<string,mixed>>,
+     *   foreignKeys:list<array<string,mixed>>,
+     *   indexes:list<array<string,mixed>>
+     * }>
+     */
+    public static function loadAll(string $documentModelsDir): array
+    {
+        if (!is_dir($documentModelsDir)) {
+            return [];
+        }
+
+        $files = glob(rtrim($documentModelsDir, '/') . '/*.json') ?: [];
+        sort($files);
+
+        $manifests = [];
+        foreach ($files as $file) {
+            $raw = file_get_contents($file);
+            if ($raw === false) {
+                continue;
+            }
+
+            $decoded = json_decode($raw, true);
+            if (!is_array($decoded)) {
+                throw new SchemaBootstrappedException('Invalid document model JSON: ' . basename($file));
+            }
+
+            $table = basename($file, '.json');
+            $constraints = [];
+            $foreignKeys = [];
+            $indexes = [];
+
+            foreach ($decoded as $key => $value) {
+                if ($key === 'foreignKeys' && is_array($value)) {
+                    $foreignKeys = $value;
+                    continue;
+                }
+                if ($key === 'indexes' && is_array($value)) {
+                    $indexes = $value;
+                    continue;
+                }
+                if (is_array($value)) {
+                    $constraints[$key] = $value;
+                }
+            }
+
+            $manifests[] = [
+                'table' => $table,
+                'file' => $file,
+                'constraints' => $constraints,
+                'foreignKeys' => $foreignKeys,
+                'indexes' => $indexes,
+            ];
+        }
+
+        return $manifests;
+    }
+
+    public static function hashDirectory(string $documentModelsDir): string
+    {
+        $manifests = self::loadAll($documentModelsDir);
+        $payload = json_encode($manifests, JSON_THROW_ON_ERROR);
+
+        return hash('sha256', $payload);
+    }
+}

--- a/src/database/schema-bootstrap/RuntimeCatalog.php
+++ b/src/database/schema-bootstrap/RuntimeCatalog.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types=1);
+
+namespace YeAPF\SchemaBootstrap;
+
+final class RuntimeCatalog
+{
+    /** @var list<array{name:string,callable:callable}> */
+    private array $entries = [];
+
+    public function register(string $name, callable $callable): void
+    {
+        $this->entries[] = ['name' => $name, 'callable' => $callable];
+    }
+
+    /**
+     * @param object $pdo YeAPF PDO connection
+     */
+    public function runAll(object $pdo, SchemaBootstrapLogger $logger, array $context = []): void
+    {
+        foreach ($this->entries as $entry) {
+            $started = hrtime(true);
+            try {
+                ($entry['callable'])($pdo, $context);
+                $durationMs = (int) ((hrtime(true) - $started) / 1_000_000);
+                $logger->append('catalog', 'ok', [
+                    'action' => $entry['name'],
+                    'duration_ms' => (string) $durationMs,
+                ]);
+            } catch (\Throwable $e) {
+                $durationMs = (int) ((hrtime(true) - $started) / 1_000_000);
+                $logger->append('catalog', 'error', [
+                    'action' => $entry['name'],
+                    'reason' => $e->getMessage(),
+                    'duration_ms' => (string) $durationMs,
+                ]);
+                throw $e;
+            }
+        }
+    }
+
+    public function count(): int
+    {
+        return count($this->entries);
+    }
+}

--- a/src/database/schema-bootstrap/SchemaAlignmentService.php
+++ b/src/database/schema-bootstrap/SchemaAlignmentService.php
@@ -1,0 +1,201 @@
+<?php declare(strict_types=1);
+
+namespace YeAPF\SchemaBootstrap;
+
+final class SchemaAlignmentService
+{
+    public function __construct(
+        private readonly SchemaBootstrapLogger $logger
+    ) {
+    }
+
+    /**
+     * Align all document models using PersistentCollection grantCollection + FK/index DDL.
+     *
+     * @param \YeAPF\Connection\PersistenceContext $context
+     */
+    public function alignAll(
+        object $context,
+        string $documentModelsDir,
+        object $pdo
+    ): void {
+        $manifests = DocumentModelManifest::loadAll($documentModelsDir);
+
+        foreach ($manifests as $manifest) {
+            $this->alignCollection($context, $manifest, $pdo);
+        }
+    }
+
+    /**
+     * @param \YeAPF\Connection\PersistenceContext $context
+     * @param array<string,mixed> $manifest
+     */
+    private function alignCollection(object $context, array $manifest, object $pdo): void
+    {
+        $table = (string) $manifest['table'];
+        $started = hrtime(true);
+
+        $model = new \YeAPF\ORM\DocumentModel($context, $table);
+        foreach ($manifest['constraints'] as $field => $constraint) {
+            if (!is_array($constraint)) {
+                continue;
+            }
+            $type = $constraint['type'] ?? YeAPF_TYPE_STRING;
+            $model->setConstraint(
+                $field,
+                $type,
+                length: $constraint['length'] ?? null,
+                primary: (bool) ($constraint['primary'] ?? false),
+                required: (bool) ($constraint['required'] ?? false),
+                acceptNULL: (bool) ($constraint['acceptNULL'] ?? true),
+                unique: (bool) ($constraint['unique'] ?? false),
+                protobufOrder: (int) ($constraint['protobufOrder'] ?? 0)
+            );
+        }
+
+        $collection = new \YeAPF\ORM\PersistentCollection(
+            $context,
+            $table,
+            $this->resolveIdField($manifest['constraints']),
+            $model
+        );
+
+        $durationMs = (int) ((hrtime(true) - $started) / 1_000_000);
+        $this->logger->append('align', 'ok', [
+            'collection' => $table,
+            'action' => 'grant_collection',
+            'duration_ms' => (string) $durationMs,
+        ]);
+
+        foreach ($manifest['foreignKeys'] as $fk) {
+            if (!is_array($fk)) {
+                continue;
+            }
+            $this->applyForeignKey($pdo, $table, $fk);
+        }
+
+        foreach ($manifest['indexes'] as $index) {
+            if (!is_array($index)) {
+                continue;
+            }
+            $this->applyIndex($pdo, $table, $index);
+        }
+    }
+
+    /**
+     * @param array<string,array<string,mixed>> $constraints
+     */
+    private function resolveIdField(array $constraints): string
+    {
+        foreach ($constraints as $name => $constraint) {
+            if (!empty($constraint['primary'])) {
+                return (string) $name;
+            }
+        }
+
+        return 'id';
+    }
+
+    /**
+     * @param array<string,mixed> $fk
+     */
+    private function applyForeignKey(object $pdo, string $table, array $fk): void
+    {
+        $columns = $fk['columns'] ?? [];
+        $references = $fk['references'] ?? '';
+        if (!is_array($columns) || $columns === [] || $references === '') {
+            return;
+        }
+
+        $constraintName = $fk['name'] ?? ('fk_' . $table . '_' . implode('_', $columns));
+        if ($this->foreignKeyExists($pdo, $table, (string) $constraintName)) {
+            return;
+        }
+
+        $onDelete = strtoupper((string) ($fk['onDelete'] ?? 'NO ACTION'));
+        $cols = implode(', ', array_map(static fn ($c) => '"' . $c . '"', $columns));
+        $sql = sprintf(
+            'ALTER TABLE "%s" ADD CONSTRAINT "%s" FOREIGN KEY (%s) REFERENCES "%s"(id) ON DELETE %s',
+            $table,
+            $constraintName,
+            $cols,
+            $references,
+            $onDelete
+        );
+
+        $pdo->query($sql);
+        $this->logger->append('align', 'ok', [
+            'collection' => $table,
+            'action' => 'add_foreign_key',
+            'column' => implode(',', $columns),
+        ]);
+    }
+
+    /**
+     * @param array<string,mixed> $index
+     */
+    private function applyIndex(object $pdo, string $table, array $index): void
+    {
+        $name = (string) ($index['name'] ?? '');
+        $columns = $index['columns'] ?? [];
+        if ($name === '' || !is_array($columns) || $columns === []) {
+            return;
+        }
+
+        if ($this->indexExists($pdo, $table, $name)) {
+            return;
+        }
+
+        $unique = !empty($index['unique']) ? 'UNIQUE ' : '';
+        $cols = implode(', ', array_map(static fn ($c) => '"' . $c . '"', $columns));
+        $where = isset($index['where']) ? ' WHERE ' . $index['where'] : '';
+        $sql = sprintf(
+            'CREATE %sINDEX "%s" ON "%s" (%s)%s',
+            $unique,
+            $name,
+            $table,
+            $cols,
+            $where
+        );
+
+        $pdo->query($sql);
+        $this->logger->append('align', 'ok', [
+            'collection' => $table,
+            'action' => 'add_index',
+            'column' => $name,
+        ]);
+    }
+
+    private function foreignKeyExists(object $pdo, string $table, string $constraintName): bool
+    {
+        $sql = 'SELECT 1 FROM information_schema.table_constraints
+                WHERE constraint_name = ' . $this->sqlLiteral($constraintName) . '
+                AND table_name = ' . $this->sqlLiteral($table) . '
+                LIMIT 1';
+        $result = $pdo->query($sql);
+        if ($result === false) {
+            return false;
+        }
+
+        return (bool) $result->fetch();
+    }
+
+    private function indexExists(object $pdo, string $table, string $indexName): bool
+    {
+        $sql = 'SELECT 1 FROM pg_indexes
+                WHERE indexname = ' . $this->sqlLiteral($indexName) . '
+                AND tablename = ' . $this->sqlLiteral($table) . '
+                LIMIT 1';
+        $result = $pdo->query($sql);
+        if ($result === false) {
+            return false;
+        }
+
+        return (bool) $result->fetch();
+    }
+
+    private function sqlLiteral(string $value): string
+    {
+        return "'" . str_replace("'", "''", $value) . "'";
+    }
+}

--- a/src/database/schema-bootstrap/SchemaBootstrapFilesystemLock.php
+++ b/src/database/schema-bootstrap/SchemaBootstrapFilesystemLock.php
@@ -1,0 +1,105 @@
+<?php declare(strict_types=1);
+
+namespace YeAPF\SchemaBootstrap;
+
+final class SchemaBootstrapFilesystemLock
+{
+    /** @var resource|null */
+    private $handle = null;
+
+    public function __construct(
+        private readonly SchemaBootstrapPaths $paths,
+        private readonly SchemaBootstrapLogger $logger
+    ) {
+    }
+
+    public function isLocked(): bool
+    {
+        $lockFile = $this->paths->lockFile();
+        if (!is_file($lockFile)) {
+            return false;
+        }
+
+        if ($this->isStaleLock($lockFile)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    public function acquire(): void
+    {
+        $this->paths->ensureBaseDir();
+        $lockFile = $this->paths->lockFile();
+
+        if ($this->isStaleLock($lockFile)) {
+            @unlink($lockFile);
+        }
+
+        $fp = fopen($lockFile, 'c+');
+        if ($fp === false) {
+            throw new SchemaBootstrappedException('Cannot open schema bootstrap lock file');
+        }
+
+        if (!flock($fp, LOCK_EX | LOCK_NB)) {
+            fclose($fp);
+            throw new SchemaBootstrappedException('Schema bootstrap lock is held by another process');
+        }
+
+        $payload = json_encode([
+            'pid' => getmypid(),
+            'startedAt' => gmdate('c'),
+            'viaCLI' => php_sapi_name() === 'cli',
+            'host' => gethostname() ?: 'unknown',
+        ], JSON_THROW_ON_ERROR);
+
+        ftruncate($fp, 0);
+        rewind($fp);
+        fwrite($fp, $payload);
+        fflush($fp);
+
+        $this->handle = $fp;
+        $this->logger->append('lock', 'ok', ['action' => 'acquire_fs']);
+    }
+
+    public function release(): void
+    {
+        $lockFile = $this->paths->lockFile();
+
+        if (is_resource($this->handle)) {
+            flock($this->handle, LOCK_UN);
+            fclose($this->handle);
+            $this->handle = null;
+        }
+
+        if (is_file($lockFile)) {
+            unlink($lockFile);
+        }
+
+        $this->logger->append('lock', 'ok', ['action' => 'release_fs']);
+    }
+
+    private function isStaleLock(string $lockFile): bool
+    {
+        $raw = @file_get_contents($lockFile);
+        if ($raw === false || $raw === '') {
+            return true;
+        }
+
+        $info = json_decode($raw, true);
+        if (!is_array($info) || !isset($info['pid'])) {
+            return true;
+        }
+
+        $pid = (int) $info['pid'];
+        if ($pid <= 0) {
+            return true;
+        }
+
+        if (function_exists('posix_kill')) {
+            return !posix_kill($pid, 0);
+        }
+
+        return false;
+    }
+}

--- a/src/database/schema-bootstrap/SchemaBootstrapGate.php
+++ b/src/database/schema-bootstrap/SchemaBootstrapGate.php
@@ -1,0 +1,111 @@
+<?php declare(strict_types=1);
+
+namespace YeAPF\SchemaBootstrap;
+
+final class SchemaBootstrapGate
+{
+    private const BLOCKING_REDIS_STATES = [
+        SchemaBootstrapState::PREFLIGHT,
+        SchemaBootstrapState::MIGRATING,
+        SchemaBootstrapState::CATALOG,
+    ];
+
+    public function __construct(
+        private readonly SchemaBootstrapPaths $paths,
+        private readonly SchemaBootstrapFilesystemLock $fsLock,
+        private readonly SchemaBootstrapRedisStatus $redisStatus,
+        private readonly SchemaBootstrapState $state
+    ) {
+    }
+
+    /**
+     * Called before serving traffic or starting bootstrap CLI.
+     *
+     * @throws SchemaBootstrappedException
+     */
+    public function assertCanStart(bool $allowPendingBootstrap = false): void
+    {
+        $redis = $this->redisStatus->read();
+        if ($redis !== null) {
+            $redisState = (string) ($redis['state'] ?? '');
+            if (in_array($redisState, self::BLOCKING_REDIS_STATES, true)) {
+                throw new SchemaBootstrappedException(
+                    'Schema bootstrap in progress (redis state=' . $redisState . ')'
+                );
+            }
+        }
+
+        if ($this->fsLock->isLocked()) {
+            throw new SchemaBootstrappedException(
+                'Schema bootstrap lock file is active; quiesce workers and retry'
+            );
+        }
+
+        if ($allowPendingBootstrap) {
+            return;
+        }
+
+        $currentHash = DocumentModelManifest::hashDirectory($this->paths->documentModelsDir());
+        $lastHash = $this->readLastCompletedSchemaHash();
+
+        if ($lastHash !== null && $lastHash !== $currentHash) {
+            throw new SchemaBootstrappedException(
+                'Document models changed since last bootstrap; run y2-schema-bootstrap.php'
+            );
+        }
+
+        if ($lastHash === null && is_dir($this->paths->documentModelsDir())) {
+            throw new SchemaBootstrappedException(
+                'Schema bootstrap never completed; run y2-schema-bootstrap.php'
+            );
+        }
+    }
+
+    /**
+     * @throws SchemaBootstrappedException
+     */
+    public function assertCanRunBootstrap(bool $force = false): void
+    {
+        $redis = $this->redisStatus->read();
+        if ($redis !== null) {
+            $redisState = (string) ($redis['state'] ?? '');
+            if (in_array($redisState, self::BLOCKING_REDIS_STATES, true)) {
+                throw new SchemaBootstrappedException(
+                    'Bootstrap already running (redis state=' . $redisState . ')'
+                );
+            }
+        }
+
+        if ($this->fsLock->isLocked()) {
+            throw new SchemaBootstrappedException('Bootstrap lock file already exists');
+        }
+
+        $workers = $this->redisStatus->countActiveWorkers();
+        if ($workers > 0 && !$force) {
+            throw new SchemaBootstrappedException(
+                "Active workers detected ($workers); quiesce all YeAPF instances or use --force in dev"
+            );
+        }
+    }
+
+    public function readLastCompletedSchemaHash(): ?string
+    {
+        $marker = $this->paths->completedMarkerFile();
+        if (!is_file($marker)) {
+            return null;
+        }
+
+        $lines = file($marker, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+        if ($lines === false || $lines === []) {
+            return null;
+        }
+
+        $last = trim((string) end($lines));
+        $parts = preg_split('/\t+/', $last);
+        if (!is_array($parts) || count($parts) < 2) {
+            return null;
+        }
+
+        return $parts[1];
+    }
+}

--- a/src/database/schema-bootstrap/SchemaBootstrapLogger.php
+++ b/src/database/schema-bootstrap/SchemaBootstrapLogger.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types=1);
+
+namespace YeAPF\SchemaBootstrap;
+
+final class SchemaBootstrapLogger
+{
+    public function __construct(
+        private readonly SchemaBootstrapPaths $paths
+    ) {
+    }
+
+    public function append(
+        string $phase,
+        string $status,
+        array $fields = []
+    ): void {
+        $this->paths->ensureBaseDir();
+        $parts = [
+            gmdate('Y-m-d\TH:i:s\Z'),
+            'pid=' . getmypid(),
+            'phase=' . $phase,
+            'status=' . $status,
+        ];
+
+        foreach ($fields as $key => $value) {
+            if ($value === null || $value === '') {
+                continue;
+            }
+            $parts[] = $key . '=' . str_replace(["\t", "\n", "\r"], ' ', (string) $value);
+        }
+
+        file_put_contents(
+            $this->paths->logFile(),
+            implode("\t", $parts) . "\n",
+            FILE_APPEND | LOCK_EX
+        );
+    }
+}

--- a/src/database/schema-bootstrap/SchemaBootstrapPaths.php
+++ b/src/database/schema-bootstrap/SchemaBootstrapPaths.php
@@ -1,0 +1,86 @@
+<?php declare(strict_types=1);
+
+namespace YeAPF\SchemaBootstrap;
+
+final class SchemaBootstrapPaths
+{
+    public const SUBDIR = '.config/schema-bootstrap';
+
+    public function __construct(
+        private readonly string $applicationRoot
+    ) {
+    }
+
+    public function applicationRoot(): string
+    {
+        return $this->applicationRoot;
+    }
+
+    public function baseDir(): string
+    {
+        return rtrim($this->applicationRoot, '/') . '/' . self::SUBDIR;
+    }
+
+    public function lockFile(): string
+    {
+        return $this->baseDir() . '/lock';
+    }
+
+    public function stateFile(): string
+    {
+        return $this->baseDir() . '/state.json';
+    }
+
+    public function logFile(): string
+    {
+        return $this->baseDir() . '/bootstrap.log';
+    }
+
+    public function completedMarkerFile(): string
+    {
+        return $this->baseDir() . '/completed.marker';
+    }
+
+    public function documentModelsDir(): string
+    {
+        $candidates = [
+            rtrim($this->applicationRoot, '/') . '/database/documentModels',
+            rtrim($this->applicationRoot, '/') . '/assets/documentModels',
+        ];
+
+        foreach ($candidates as $dir) {
+            if (is_dir($dir)) {
+                return $dir;
+            }
+        }
+
+        return $candidates[0];
+    }
+
+    public function ensureBaseDir(): void
+    {
+        if (!is_dir($this->baseDir())) {
+            mkdir($this->baseDir(), 0775, true);
+        }
+    }
+
+    public static function appIdFromRoot(string $applicationRoot): string
+    {
+        return substr(hash('sha256', realpath($applicationRoot) ?: $applicationRoot), 0, 16);
+    }
+
+    public function appId(): string
+    {
+        return self::appIdFromRoot($this->applicationRoot);
+    }
+
+    public function redisStatusKey(): string
+    {
+        return 'y2:schema-bootstrap:' . $this->appId() . ':status';
+    }
+
+    public function redisWorkersKey(): string
+    {
+        return 'y2:app:' . $this->appId() . ':workers';
+    }
+}

--- a/src/database/schema-bootstrap/SchemaBootstrapRedisStatus.php
+++ b/src/database/schema-bootstrap/SchemaBootstrapRedisStatus.php
@@ -1,0 +1,132 @@
+<?php declare(strict_types=1);
+
+namespace YeAPF\SchemaBootstrap;
+
+/**
+ * Redis status for schema bootstrap. Works with real Redis or test doubles exposing get/set/del.
+ */
+final class SchemaBootstrapRedisStatus
+{
+    private const TTL_SECONDS = 3600;
+
+    public function __construct(
+        private readonly SchemaBootstrapPaths $paths,
+        private readonly ?object $redis
+    ) {
+    }
+
+    public function read(): ?array
+    {
+        if ($this->redis === null) {
+            return null;
+        }
+
+        $raw = $this->redisGet($this->paths->redisStatusKey());
+        if ($raw === false || $raw === null || $raw === '') {
+            return null;
+        }
+
+        $decoded = json_decode((string) $raw, true);
+        return is_array($decoded) ? $decoded : null;
+    }
+
+    public function write(string $state, array $extra = []): void
+    {
+        if ($this->redis === null) {
+            return;
+        }
+
+        $payload = array_merge([
+            'state' => $state,
+            'startedAt' => gmdate('c'),
+            'pid' => getmypid(),
+            'host' => gethostname() ?: 'unknown',
+        ], $extra);
+
+        $this->redisSet(
+            $this->paths->redisStatusKey(),
+            json_encode($payload, JSON_THROW_ON_ERROR),
+            self::TTL_SECONDS
+        );
+    }
+
+    public function clear(): void
+    {
+        if ($this->redis === null) {
+            return;
+        }
+
+        $this->redisDel($this->paths->redisStatusKey());
+    }
+
+    public function countActiveWorkers(): int
+    {
+        if ($this->redis === null) {
+            return 0;
+        }
+
+        if (method_exists($this->redis, 'scard')) {
+            $count = $this->redis->scard($this->paths->redisWorkersKey());
+            return is_int($count) ? $count : 0;
+        }
+
+        if (method_exists($this->redis, 'hgetall')) {
+            $all = $this->redis->hgetall($this->paths->redisWorkersKey());
+            return is_array($all) ? count($all) : 0;
+        }
+
+        return 0;
+    }
+
+    public function registerWorkerHeartbeat(string $workerId): void
+    {
+        if ($this->redis === null) {
+            return;
+        }
+
+        if (method_exists($this->redis, 'sadd')) {
+            $this->redis->sadd($this->paths->redisWorkersKey(), $workerId);
+            if (method_exists($this->redis, 'expire')) {
+                $this->redis->expire($this->paths->redisWorkersKey(), 120);
+            }
+            return;
+        }
+
+        if (method_exists($this->redis, 'hset')) {
+            $this->redis->hset($this->paths->redisWorkersKey(), [$workerId => (string) time()]);
+        }
+    }
+
+    private function redisGet(string $key): mixed
+    {
+        if (method_exists($this->redis, 'get')) {
+            return $this->redis->get($key);
+        }
+
+        return false;
+    }
+
+    private function redisSet(string $key, string $value, int $ttl): void
+    {
+        if (method_exists($this->redis, 'setex')) {
+            $this->redis->setex($key, $ttl, $value);
+            return;
+        }
+
+        if (method_exists($this->redis, 'set')) {
+            $this->redis->set($key, $value);
+        }
+    }
+
+    private function redisDel(string $key): void
+    {
+        if (method_exists($this->redis, 'del')) {
+            $this->redis->del($key);
+            return;
+        }
+
+        if (method_exists($this->redis, 'delete')) {
+            $this->redis->delete($key);
+        }
+    }
+}

--- a/src/database/schema-bootstrap/SchemaBootstrapState.php
+++ b/src/database/schema-bootstrap/SchemaBootstrapState.php
@@ -1,0 +1,53 @@
+<?php declare(strict_types=1);
+
+namespace YeAPF\SchemaBootstrap;
+
+final class SchemaBootstrapState
+{
+    public const IDLE = 'idle';
+    public const PREFLIGHT = 'preflight';
+    public const MIGRATING = 'migrating';
+    public const CATALOG = 'catalog';
+    public const COMPLETED = 'completed';
+    public const FAILED = 'failed';
+
+    public function __construct(
+        private readonly SchemaBootstrapPaths $paths
+    ) {
+    }
+
+    public function read(): string
+    {
+        if (!is_file($this->paths->stateFile())) {
+            return self::IDLE;
+        }
+
+        $raw = file_get_contents($this->paths->stateFile());
+        if ($raw === false || $raw === '') {
+            return self::IDLE;
+        }
+
+        $decoded = json_decode($raw, true);
+        if (!is_array($decoded) || !isset($decoded['state'])) {
+            return self::IDLE;
+        }
+
+        return (string) $decoded['state'];
+    }
+
+    public function write(string $state, array $extra = []): void
+    {
+        $this->paths->ensureBaseDir();
+        $payload = array_merge([
+            'state' => $state,
+            'updatedAt' => gmdate('c'),
+            'pid' => getmypid(),
+            'host' => gethostname() ?: 'unknown',
+        ], $extra);
+
+        file_put_contents(
+            $this->paths->stateFile(),
+            json_encode($payload, JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT)
+        );
+    }
+}

--- a/src/database/schema-bootstrap/SchemaBootstrapWorkerRegistry.php
+++ b/src/database/schema-bootstrap/SchemaBootstrapWorkerRegistry.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types=1);
+
+namespace YeAPF\SchemaBootstrap;
+
+/**
+ * Call at YeAPF worker boot so schema bootstrap can detect active instances.
+ */
+final class SchemaBootstrapWorkerRegistry
+{
+    public static function heartbeat(string $applicationRoot, ?object $redis, string $workerId): void
+    {
+        $paths = new SchemaBootstrapPaths($applicationRoot);
+        $status = new SchemaBootstrapRedisStatus($paths, $redis);
+        $status->registerWorkerHeartbeat($workerId);
+    }
+}

--- a/src/database/schema-bootstrap/SchemaBootstrappedException.php
+++ b/src/database/schema-bootstrap/SchemaBootstrappedException.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+
+namespace YeAPF\SchemaBootstrap;
+
+final class SchemaBootstrappedException extends \RuntimeException
+{
+    public function __construct(
+        string $message,
+        private readonly int $httpStatus = 503,
+        ?\Throwable $previous = null
+    ) {
+        parent::__construct($message, 0, $previous);
+    }
+
+    public function getHttpStatus(): int
+    {
+        return $this->httpStatus;
+    }
+}

--- a/src/database/schema-bootstrap/SchemaSessionOrchestrator.php
+++ b/src/database/schema-bootstrap/SchemaSessionOrchestrator.php
@@ -1,0 +1,161 @@
+<?php declare(strict_types=1);
+
+namespace YeAPF\SchemaBootstrap;
+
+final class SchemaSessionOrchestrator
+{
+    private const ADVISORY_LOCK_KEY = 75843021;
+
+    public function __construct(
+        private readonly SchemaBootstrapPaths $paths,
+        private readonly SchemaBootstrapGate $gate,
+        private readonly SchemaBootstrapFilesystemLock $fsLock,
+        private readonly SchemaBootstrapRedisStatus $redisStatus,
+        private readonly SchemaBootstrapState $state,
+        private readonly SchemaBootstrapLogger $logger,
+        private readonly SchemaAlignmentService $alignment,
+        private readonly RuntimeCatalog $catalog
+    ) {
+    }
+
+    /**
+     * @param \YeAPF\Connection\PersistenceContext $context
+     */
+    public function run(
+        object $context,
+        object $pdo,
+        bool $force = false
+    ): string {
+        $this->gate->assertCanRunBootstrap($force);
+
+        if ($force && $this->redisStatus->countActiveWorkers() > 0) {
+            $this->logger->append('preflight', 'ok', [
+                'action' => 'force_with_active_workers',
+                'reason' => 'dev override',
+            ]);
+        }
+
+        $schemaHash = DocumentModelManifest::hashDirectory($this->paths->documentModelsDir());
+
+        try {
+            $this->redisStatus->write(SchemaBootstrapState::PREFLIGHT, ['schemaHash' => $schemaHash]);
+            $this->state->write(SchemaBootstrapState::PREFLIGHT, ['schemaHash' => $schemaHash]);
+            $this->logger->append('preflight', 'ok', ['action' => 'started', 'schemaHash' => $schemaHash]);
+
+            $this->fsLock->acquire();
+
+            $this->acquireAdvisoryLock($pdo);
+            $pdo->query('BEGIN');
+
+            $this->state->write(SchemaBootstrapState::MIGRATING, ['schemaHash' => $schemaHash]);
+            $this->redisStatus->write(SchemaBootstrapState::MIGRATING, ['schemaHash' => $schemaHash]);
+
+            $this->alignment->alignAll($context, $this->paths->documentModelsDir(), $pdo);
+
+            $this->state->write(SchemaBootstrapState::CATALOG, ['schemaHash' => $schemaHash]);
+            $this->redisStatus->write(SchemaBootstrapState::CATALOG, ['schemaHash' => $schemaHash]);
+            $this->catalog->runAll($pdo, $this->logger, ['applicationRoot' => $this->paths->applicationRoot()]);
+
+            $pdo->query('COMMIT');
+            $this->releaseAdvisoryLock($pdo);
+
+            $catalogVersion = (string) $this->catalog->count();
+            $this->appendCompletedMarker($schemaHash, $catalogVersion);
+
+            $this->fsLock->release();
+            $this->redisStatus->write(SchemaBootstrapState::COMPLETED, [
+                'schemaHash' => $schemaHash,
+                'catalogVersion' => $catalogVersion,
+            ]);
+            $this->state->write(SchemaBootstrapState::COMPLETED, [
+                'schemaHash' => $schemaHash,
+                'catalogVersion' => $catalogVersion,
+            ]);
+
+            $this->logger->append('completed', 'ok', [
+                'schemaHash' => $schemaHash,
+                'catalogVersion' => $catalogVersion,
+            ]);
+
+            return $schemaHash;
+        } catch (\Throwable $e) {
+            try {
+                $pdo->query('ROLLBACK');
+            } catch (\Throwable) {
+            }
+
+            try {
+                $this->releaseAdvisoryLock($pdo);
+            } catch (\Throwable) {
+            }
+
+            $this->fsLock->release();
+            $this->state->write(SchemaBootstrapState::FAILED, ['reason' => $e->getMessage()]);
+            $this->redisStatus->write(SchemaBootstrapState::FAILED, ['reason' => $e->getMessage()]);
+
+            $this->logger->append('failed', 'error', ['reason' => $e->getMessage()]);
+            throw $e;
+        }
+    }
+
+    /**
+     * @param \YeAPF\Connection\PersistenceContext $context
+     */
+    public static function factory(
+        string $applicationRoot,
+        object $context,
+        ?object $redis = null
+    ): self {
+        $paths = new SchemaBootstrapPaths($applicationRoot);
+        $logger = new SchemaBootstrapLogger($paths);
+        $state = new SchemaBootstrapState($paths);
+        $fsLock = new SchemaBootstrapFilesystemLock($paths, $logger);
+        $redisStatus = new SchemaBootstrapRedisStatus($paths, $redis);
+        $gate = new SchemaBootstrapGate($paths, $fsLock, $redisStatus, $state);
+        $alignment = new SchemaAlignmentService($logger);
+        $catalog = new RuntimeCatalog();
+
+        return new self($paths, $gate, $fsLock, $redisStatus, $state, $logger, $alignment, $catalog);
+    }
+
+    public function gate(): SchemaBootstrapGate
+    {
+        return $this->gate;
+    }
+
+    public function catalog(): RuntimeCatalog
+    {
+        return $this->catalog;
+    }
+
+    public function paths(): SchemaBootstrapPaths
+    {
+        return $this->paths;
+    }
+
+    public function logger(): SchemaBootstrapLogger
+    {
+        return $this->logger;
+    }
+
+    private function acquireAdvisoryLock(object $pdo): void
+    {
+        $sql = 'SELECT pg_advisory_lock(' . self::ADVISORY_LOCK_KEY . ')';
+        $pdo->query($sql);
+        $this->logger->append('migrate', 'ok', ['action' => 'pg_advisory_lock']);
+    }
+
+    private function releaseAdvisoryLock(object $pdo): void
+    {
+        $sql = 'SELECT pg_advisory_unlock(' . self::ADVISORY_LOCK_KEY . ')';
+        $pdo->query($sql);
+        $this->logger->append('migrate', 'ok', ['action' => 'pg_advisory_unlock']);
+    }
+
+    private function appendCompletedMarker(string $schemaHash, string $catalogVersion): void
+    {
+        $this->paths->ensureBaseDir();
+        $line = gmdate('c') . "\t" . $schemaHash . "\t" . $catalogVersion . "\n";
+        file_put_contents($this->paths->completedMarkerFile(), $line, FILE_APPEND | LOCK_EX);
+    }
+}

--- a/src/database/schema-bootstrap/schema-bootstrap.php
+++ b/src/database/schema-bootstrap/schema-bootstrap.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+
+require_once __DIR__ . '/SchemaBootstrappedException.php';
+require_once __DIR__ . '/SchemaBootstrapPaths.php';
+require_once __DIR__ . '/SchemaBootstrapLogger.php';
+require_once __DIR__ . '/SchemaBootstrapState.php';
+require_once __DIR__ . '/SchemaBootstrapFilesystemLock.php';
+require_once __DIR__ . '/SchemaBootstrapRedisStatus.php';
+require_once __DIR__ . '/DocumentModelManifest.php';
+require_once __DIR__ . '/SchemaBootstrapGate.php';
+require_once __DIR__ . '/RuntimeCatalog.php';
+require_once __DIR__ . '/SchemaAlignmentService.php';
+require_once __DIR__ . '/SchemaSessionOrchestrator.php';
+require_once __DIR__ . '/SchemaBootstrapWorkerRegistry.php';

--- a/src/yeapf-core.php
+++ b/src/yeapf-core.php
@@ -119,6 +119,7 @@ require_once __DIR__ . '/yeapf-config.php';
     'database/yeapf-pdo-connection.php',
     'database/yeapf-persistence-interface.php',
     'database/yeapf-collections.php',
+    'database/schema-bootstrap/schema-bootstrap.php',
     'database/yeapf-eyeshot.php',
     'service/yeapf-service-skeleton.php',
     'service/yeapf-http2-service.php',

--- a/tests/README.testing.md
+++ b/tests/README.testing.md
@@ -1,0 +1,36 @@
+# Y2 — testes e handoff para agentes
+
+Este diretório contém a suíte PHPUnit do framework. O contrato completo entre **IA de testes** e **IA programadora** está no monorepo ERP-DryWall:
+
+`~/Sync/Projects/YouBR/ERP-DryWall/docs/agents/test-runner-handoff.md` (contrato canônico test runner ↔ programador).
+
+## Pré-requisitos
+
+```bash
+cd tests && composer install
+cd tests/db-environments && docker compose up -d postgres   # porta 55432
+```
+
+## Comandos
+
+| Comando | Uso |
+|---------|-----|
+| `./tests/run-handoff.sh` | Suíte completa `yeapf2` + artefatos em `.test-results/latest/` |
+| `./tests/run-handoff.sh schema-bootstrap` | Só `SchemaSessionBootstrapTest` |
+| `php -d opcache.enable_cli=0 ./vendor/bin/phpunit -c phpunit.xml` | PHPUnit direto (sem artefatos de handoff) |
+
+## Artefatos (não commitar)
+
+Diretório padrão: `Y2/.test-results/latest/`
+
+- `summary.txt` — PASS/FAIL em uma linha
+- `exit-code.txt` — código de saída do PHPUnit
+- `junit.xml` — falhas estruturadas
+- `testdox.txt` — nomes legíveis dos testes
+- `console.txt` — stdout/stderr completo
+- `meta.txt` — repo, suite, timestamps
+
+## Suítes (`phpunit.xml`)
+
+- **yeapf2** — todos os `*Test.php` neste diretório (exclui `vendor/`, `helpers/`, `fixtures/`)
+- **schema-bootstrap** — bootstrap de schema / trava distribuída

--- a/tests/SchemaSessionBootstrapTest.php
+++ b/tests/SchemaSessionBootstrapTest.php
@@ -1,0 +1,273 @@
+<?php declare(strict_types=1);
+
+require_once __DIR__ . '/../src/yeapf-core.php';
+require_once __DIR__ . '/helpers/SchemaBootstrapTestRedis.php';
+
+use PHPUnit\Framework\TestCase;
+
+final class SchemaSessionBootstrapTest extends TestCase
+{
+    private const HOST = '127.0.0.1';
+    private const PORT = 55432;
+    private const DB = 'yeapf2_test';
+    private const USER = 'yeapf2';
+    private const PASSWORD = 'yeapf2';
+    private const TABLE = 'demo_users';
+
+    private string $appRoot;
+
+    /** @var array<string,mixed>|null */
+    private static ?array $previousConfigAreas = null;
+
+    protected function setUp(): void
+    {
+        if (!self::isDockerDbReachable()) {
+            $this->markTestSkipped('PostgreSQL docker container is not reachable at 127.0.0.1:55432');
+        }
+
+        $this->appRoot = sys_get_temp_dir() . '/y2-schema-bootstrap-' . bin2hex(random_bytes(4));
+        mkdir($this->appRoot . '/.config', 0775, true);
+        mkdir($this->appRoot . '/database/documentModels', 0775, true);
+        copy(
+            __DIR__ . '/fixtures/schema-bootstrap/documentModels/demo_users.json',
+            $this->appRoot . '/database/documentModels/demo_users.json'
+        );
+
+        self::backupAndSetRuntimeConnectionConfig();
+        self::resetPdoConnectionStatics();
+        self::dropDemoTable();
+        $this->resetBootstrapArtifacts();
+    }
+
+    protected function tearDown(): void
+    {
+        if (self::isDockerDbReachable()) {
+            self::dropDemoTable();
+            self::resetPdoConnectionStatics();
+            self::restoreRuntimeConnectionConfig();
+        }
+        $this->removeDirectory($this->appRoot);
+    }
+
+    public function testBootstrapCreatesTableAndIsIdempotent(): void
+    {
+        $redis = new SchemaBootstrapTestRedis();
+        $context = new \YeAPF\Connection\PersistenceContext(null, null);
+        $orchestrator = \YeAPF\SchemaBootstrap\SchemaSessionOrchestrator::factory($this->appRoot, $context, $redis);
+
+        $catalogRuns = 0;
+        $orchestrator->catalog()->register('count-run', static function () use (&$catalogRuns): void {
+            $catalogRuns++;
+        });
+
+        $hash1 = $this->withPdo(static fn ($pdo) => $orchestrator->run(
+            $context,
+            $pdo,
+            false
+        ));
+
+        $this->assertNotSame('', $hash1);
+        $this->assertTrue(self::tableExists());
+        $this->assertFileExists($this->appRoot . '/.config/schema-bootstrap/completed.marker');
+        $this->assertFileDoesNotExist($this->appRoot . '/.config/schema-bootstrap/lock');
+        $this->assertSame(1, $catalogRuns);
+
+        $log = file_get_contents($this->appRoot . '/.config/schema-bootstrap/bootstrap.log');
+        $this->assertIsString($log);
+        $this->assertStringContainsString('phase=align', $log);
+        $this->assertStringContainsString('phase=completed', $log);
+
+        $hash2 = $this->withPdo(static fn ($pdo) => $orchestrator->run(
+            $context,
+            $pdo,
+            false
+        ));
+
+        $this->assertSame($hash1, $hash2);
+        $this->assertSame(2, $catalogRuns);
+    }
+
+    public function testGateBlocksWhenRedisShowsMigrating(): void
+    {
+        $redis = new SchemaBootstrapTestRedis();
+        $paths = new \YeAPF\SchemaBootstrap\SchemaBootstrapPaths($this->appRoot);
+        $redis->setex(
+            $paths->redisStatusKey(),
+            60,
+            json_encode(['state' => \YeAPF\SchemaBootstrap\SchemaBootstrapState::MIGRATING], JSON_THROW_ON_ERROR)
+        );
+
+        $context = new \YeAPF\Connection\PersistenceContext(null, null);
+        $orchestrator = \YeAPF\SchemaBootstrap\SchemaSessionOrchestrator::factory($this->appRoot, $context, $redis);
+
+        $this->expectException(\YeAPF\SchemaBootstrap\SchemaBootstrappedException::class);
+        $orchestrator->gate()->assertCanStart();
+    }
+
+    public function testBootstrapRefusesWhenWorkersActiveUnlessForce(): void
+    {
+        $redis = new SchemaBootstrapTestRedis();
+        $paths = new \YeAPF\SchemaBootstrap\SchemaBootstrapPaths($this->appRoot);
+        $redis->sadd($paths->redisWorkersKey(), 'worker-1');
+
+        $context = new \YeAPF\Connection\PersistenceContext(null, null);
+        $orchestrator = \YeAPF\SchemaBootstrap\SchemaSessionOrchestrator::factory($this->appRoot, $context, $redis);
+
+        $this->expectException(\YeAPF\SchemaBootstrap\SchemaBootstrappedException::class);
+        $this->withPdo(static fn ($pdo) => $orchestrator->run($context, $pdo, false));
+    }
+
+    public function testBootstrapForceAllowedWithWorkers(): void
+    {
+        $redis = new SchemaBootstrapTestRedis();
+        $paths = new \YeAPF\SchemaBootstrap\SchemaBootstrapPaths($this->appRoot);
+        $redis->sadd($paths->redisWorkersKey(), 'worker-1');
+
+        $context = new \YeAPF\Connection\PersistenceContext(null, null);
+        $orchestrator = \YeAPF\SchemaBootstrap\SchemaSessionOrchestrator::factory($this->appRoot, $context, $redis);
+
+        $hash = $this->withPdo(static fn ($pdo) => $orchestrator->run($context, $pdo, true));
+        $this->assertNotSame('', $hash);
+        $log = file_get_contents($this->appRoot . '/.config/schema-bootstrap/bootstrap.log');
+        $this->assertStringContainsString('force_with_active_workers', (string) $log);
+    }
+
+    private function resetBootstrapArtifacts(): void
+    {
+        $base = $this->appRoot . '/.config/schema-bootstrap';
+        if (!is_dir($base)) {
+            return;
+        }
+
+        foreach (glob($base . '/*') ?: [] as $file) {
+            if (is_file($file)) {
+                unlink($file);
+            }
+        }
+    }
+
+    private function withPdo(callable $callback): mixed
+    {
+        $main = \YeAPF\Connection\DB\CreateMainPDOConnection();
+        $conn = null;
+        $main->popConnection($conn);
+        try {
+            return $callback($conn);
+        } finally {
+            $main->pushConnection($conn);
+        }
+    }
+
+    private static function tableExists(): bool
+    {
+        return (bool) self::withBorrowedConnection(static function ($pdo): bool {
+            return $pdo->tableExists(self::TABLE);
+        });
+    }
+
+    private static function dropDemoTable(): void
+    {
+        try {
+            self::withBorrowedConnection(static function ($pdo): void {
+                $pdo->query('DROP TABLE IF EXISTS "' . self::TABLE . '" CASCADE');
+            });
+        } catch (Throwable) {
+        }
+    }
+
+    private static function isDockerDbReachable(): bool
+    {
+        $socket = @fsockopen(self::HOST, self::PORT, $errno, $errstr, 1.0);
+        if ($socket === false) {
+            return false;
+        }
+        fclose($socket);
+        return true;
+    }
+
+    private static function backupAndSetRuntimeConnectionConfig(): void
+    {
+        $configClass = new ReflectionClass(\YeAPF\YeAPFConfig::class);
+        $areasProperty = $configClass->getProperty('configAreas');
+        $areasProperty->setAccessible(true);
+        $current = $areasProperty->getValue();
+        self::$previousConfigAreas = is_array($current) ? $current : [];
+
+        $areasProperty->setValue([
+            'connection' => (object) [
+                'pdo' => (object) [
+                    'driver' => 'pgsql',
+                    'server' => self::HOST,
+                    'port' => self::PORT,
+                    'dbname' => self::DB,
+                    'schema' => 'public',
+                    'user' => self::USER,
+                    'password' => self::PASSWORD,
+                    'halt_on_error' => true,
+                    'pool' => 1,
+                ],
+            ],
+            'mode' => (object) [
+                'debug' => (object) ['enabled' => false, 'level' => 'WARNING', 'facility' => [], 'areas' => []],
+                'trace' => (object) ['enabled' => false, 'level' => 'EMERG', 'areas' => []],
+            ],
+            'randomness' => (object) ['namespace' => '6ba7b810-9dad-11d1-80b4-00c04fd430c8'],
+        ]);
+    }
+
+    private static function restoreRuntimeConnectionConfig(): void
+    {
+        $configClass = new ReflectionClass(\YeAPF\YeAPFConfig::class);
+        $areasProperty = $configClass->getProperty('configAreas');
+        $areasProperty->setAccessible(true);
+        $areasProperty->setValue(self::$previousConfigAreas ?? []);
+    }
+
+    private static function resetPdoConnectionStatics(): void
+    {
+        $reflection = new ReflectionClass(\YeAPF\Connection\DB\PDOConnection::class);
+        foreach (['config', 'db', 'trulyConnected', 'connectionString', 'pool', 'poolId', 'mainConnection'] as $propertyName) {
+            $property = $reflection->getProperty($propertyName);
+            $property->setAccessible(true);
+            $property->setValue(null, $propertyName === 'pool' ? [] : null);
+        }
+    }
+
+    private static function withBorrowedConnection(callable $callback): mixed
+    {
+        $main = \YeAPF\Connection\DB\CreateMainPDOConnection();
+        $conn = null;
+        $main->popConnection($conn);
+        try {
+            return $callback($conn);
+        } finally {
+            $main->pushConnection($conn);
+        }
+    }
+
+    private function removeDirectory(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+
+        $items = scandir($dir);
+        if ($items === false) {
+            return;
+        }
+
+        foreach ($items as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $item;
+            if (is_dir($path)) {
+                $this->removeDirectory($path);
+            } else {
+                unlink($path);
+            }
+        }
+
+        rmdir($dir);
+    }
+}

--- a/tests/composer.json
+++ b/tests/composer.json
@@ -1,5 +1,11 @@
 {
     "require-dev": {
         "phpunit/phpunit": "^10"
+    },
+    "scripts": {
+        "test": "php -d opcache.enable_cli=0 vendor/bin/phpunit -c phpunit.xml",
+        "test:schema-bootstrap": "php -d opcache.enable_cli=0 vendor/bin/phpunit -c phpunit.xml --testsuite schema-bootstrap",
+        "test:handoff": "bash run-handoff.sh",
+        "test:handoff:schema-bootstrap": "bash run-handoff.sh schema-bootstrap"
     }
 }

--- a/tests/fixtures/schema-bootstrap/documentModels/demo_users.json
+++ b/tests/fixtures/schema-bootstrap/documentModels/demo_users.json
@@ -1,0 +1,54 @@
+{
+  "id": {
+    "type": "STRING",
+    "primary": true,
+    "required": true,
+    "acceptNULL": false,
+    "length": 15,
+    "protobufOrder": 1
+  },
+  "name": {
+    "type": "STRING",
+    "length": 120,
+    "required": true,
+    "acceptNULL": false,
+    "protobufOrder": 2
+  },
+  "email": {
+    "type": "STRING",
+    "length": 180,
+    "required": true,
+    "acceptNULL": false,
+    "unique": true,
+    "protobufOrder": 3
+  },
+  "created_by_id": {
+    "type": "STRING",
+    "length": 15,
+    "required": false,
+    "acceptNULL": true,
+    "protobufOrder": 4
+  },
+  "deleted_at": {
+    "type": "DATETIME",
+    "required": false,
+    "acceptNULL": true,
+    "protobufOrder": 5
+  },
+  "foreignKeys": [
+    {
+      "name": "fk_demo_users_created_by",
+      "columns": ["created_by_id"],
+      "references": "demo_users",
+      "onDelete": "SET NULL"
+    }
+  ],
+  "indexes": [
+    {
+      "name": "demo_users_email_active",
+      "columns": ["email"],
+      "where": "deleted_at IS NULL",
+      "unique": true
+    }
+  ]
+}

--- a/tests/helpers/SchemaBootstrapTestRedis.php
+++ b/tests/helpers/SchemaBootstrapTestRedis.php
@@ -1,0 +1,54 @@
+<?php declare(strict_types=1);
+
+/**
+ * In-memory Redis double for schema bootstrap tests (string keys + sets).
+ */
+final class SchemaBootstrapTestRedis
+{
+    /** @var array<string,string> */
+    private array $strings = [];
+
+    /** @var array<string,array<string,bool>> */
+    private array $sets = [];
+
+    public function get(string $key): string|false
+    {
+        return $this->strings[$key] ?? false;
+    }
+
+    public function setex(string $key, int $ttl, string $value): bool
+    {
+        unset($ttl);
+        $this->strings[$key] = $value;
+        return true;
+    }
+
+    public function set(string $key, string $value): bool
+    {
+        $this->strings[$key] = $value;
+        return true;
+    }
+
+    public function del(string $key): int
+    {
+        unset($this->strings[$key]);
+        return 1;
+    }
+
+    public function sadd(string $key, string $member): int
+    {
+        $this->sets[$key][$member] = true;
+        return 1;
+    }
+
+    public function scard(string $key): int
+    {
+        return isset($this->sets[$key]) ? count($this->sets[$key]) : 0;
+    }
+
+    public function expire(string $key, int $ttl): bool
+    {
+        unset($ttl);
+        return isset($this->sets[$key]) || isset($this->strings[$key]);
+    }
+}

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="../src/yeapf-core.php"
+         colors="true"
+         cacheDirectory=".phpunit.cache"
+         failOnWarning="false"
+         failOnDeprecation="false">
+    <testsuites>
+        <testsuite name="yeapf2">
+            <directory suffix="Test.php">.</directory>
+            <exclude>./vendor</exclude>
+            <exclude>./helpers</exclude>
+            <exclude>./fixtures</exclude>
+            <exclude>./db-environments</exclude>
+        </testsuite>
+        <testsuite name="schema-bootstrap">
+            <file>SchemaSessionBootstrapTest.php</file>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/run-handoff.sh
+++ b/tests/run-handoff.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# ---------------------------------------------------------------------------
+# YeAPF2 (Y2) — test handoff runner
+#
+# Runs PHPUnit and writes machine-readable artifacts for a programmer agent.
+# Does NOT fix code. See ERP-DryWall docs/agents/test-runner-handoff.md
+#
+# Usage:
+#   ./tests/run-handoff.sh
+#   ./tests/run-handoff.sh schema-bootstrap    # subset only
+#   Y2_TEST_RESULTS_DIR=/tmp/y2-out ./tests/run-handoff.sh
+# ---------------------------------------------------------------------------
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TESTS_DIR="$ROOT/tests"
+OUT="${Y2_TEST_RESULTS_DIR:-$ROOT/.test-results/latest}"
+SUITE="${1:-yeapf2}"
+
+mkdir -p "$OUT"
+TIMESTAMP="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+{
+  echo "repo=Y2"
+  echo "suite=$SUITE"
+  echo "started_at=$TIMESTAMP"
+  echo "php_version=$(php -r 'echo PHP_VERSION;')"
+  echo "command=./tests/run-handoff.sh $SUITE"
+} >"$OUT/meta.txt"
+
+if [[ ! -x "$TESTS_DIR/vendor/bin/phpunit" ]]; then
+  echo "ERROR: run 'composer install' in $TESTS_DIR first" | tee "$OUT/console.txt"
+  echo 127 >"$OUT/exit-code.txt"
+  exit 127
+fi
+
+echo "Starting PostgreSQL (tests/db-environments)..." | tee -a "$OUT/console.txt"
+(
+  cd "$TESTS_DIR/db-environments"
+  docker compose up -d postgres 2>&1
+) | tee -a "$OUT/console.txt"
+
+cd "$TESTS_DIR"
+
+PHPUNIT_ARGS=(
+  -c phpunit.xml
+  "--testsuite" "$SUITE"
+  "--log-junit" "$OUT/junit.xml"
+  "--testdox-text" "$OUT/testdox.txt"
+)
+
+set +e
+php -d opcache.enable_cli=0 ./vendor/bin/phpunit "${PHPUNIT_ARGS[@]}" 2>&1 | tee -a "$OUT/console.txt"
+EXIT=$?
+set -e
+
+echo "$EXIT" >"$OUT/exit-code.txt"
+echo "finished_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >>"$OUT/meta.txt"
+echo "exit_code=$EXIT" >>"$OUT/meta.txt"
+
+# Human-readable one-liner for the fixer agent
+if [[ "$EXIT" -eq 0 ]]; then
+  echo "PASS — suite=$SUITE — artifacts in $OUT" >"$OUT/summary.txt"
+else
+  echo "FAIL — suite=$SUITE — read $OUT/junit.xml and $OUT/console.txt" >"$OUT/summary.txt"
+fi
+
+exit "$EXIT"


### PR DESCRIPTION
## Summary

- Add schema bootstrap module: Gate, Orchestrator, AlignmentService, RuntimeCatalog
- Distributed lock: Redis status + filesystem flock under `.config/schema-bootstrap/`
- CLI `bin/y2-schema-bootstrap.php` and PostgreSQL contract tests
- Loader wired in `yeapf-core.php`

## Related issue

Epic `schema-session-bootstrap` / SSB-001 (local tracking under `docs/issues/`, gitignored per repo policy)

## How to test

```bash
cd tests/db-environments && docker compose up -d postgres
cd tests && php -d opcache.enable_cli=0 ./vendor/bin/phpunit SchemaSessionBootstrapTest.php
```

## Risks / Rollback

- New code paths are opt-in via CLI/bootstrap gate; existing apps unchanged until integrated
- Rollback: revert merge; no migration of persisted data in this PR

## Security impact

No security impact — infrastructure for schema coordination only

## Checklist

- [x] PHPUnit SchemaSessionBootstrapTest (4 tests, 14 assertions)
- [x] Branch matches issue naming `issue/schema-session-bootstrap/session-orchestrator`

Made with [Cursor](https://cursor.com)