### PR TITLE
fix(php8.4): explicit nullable (?T) on params defaulting to null

### DIFF
--- a/src/classes/class.key-data.php
+++ b/src/classes/class.key-data.php
@@ -278,7 +278,7 @@ class SanitizedKeyData extends KeyData
 {
   private $__constraints = [];
 
-  public function __construct(array $constraints = null)
+  public function __construct(?array $constraints = null)
   {
     parent::__construct();
     if (null !== $constraints) {
@@ -506,7 +506,7 @@ class SanitizedKeyData extends KeyData
    *
    * @return array The constraints associated with this object.
    */
-  public function getConstraints(bool $asInterface = null, string $tag = null)
+  public function getConstraints(?bool $asInterface = null, ?string $tag = null)
   {
     if (is_null($asInterface) && is_null($tag)) {
       return $this->__constraints;

--- a/src/database/yeapf-collections.php
+++ b/src/database/yeapf-collections.php
@@ -79,7 +79,7 @@ class VirtualRedis
         );
     }
 
-    public function hset(string $name, mixed $data, int $expiration = null)
+    public function hset(string $name, mixed $data, ?int $expiration = null)
     {
         if (!is_iterable($data)) {
             return false;
@@ -626,7 +626,7 @@ interface iCollection
         \YeAPF\Connection\PersistenceContext $context,
         string $collectionName,
         string $collectionIdName                = 'id',
-        \YeAPF\ORM\DocumentModel $documentModel = null,
+        ?\YeAPF\ORM\DocumentModel $documentModel = null,
         int $cacheExpiration                    = 0
     );
 
@@ -700,7 +700,7 @@ class SharedSanitizedCollection extends \YeAPF\ORM\SharedSanitizedKeyData implem
         \YeAPF\Connection\PersistenceContext $context,
         string $collectionName,
         string $collectionIdName                = 'id',
-        \YeAPF\ORM\DocumentModel $documentModel = null,
+        ?\YeAPF\ORM\DocumentModel $documentModel = null,
         int $cacheExpiration                    = 0
     ) {
         parent::__construct($context);
@@ -964,7 +964,7 @@ class PersistentCollection extends \YeAPF\ORM\SharedSanitizedCollection implemen
         \YeAPF\Connection\PersistenceContext $context,
         string $collectionName,
         string $collectionIdName                = 'id',
-        \YeAPF\ORM\DocumentModel $documentModel = null,
+        ?\YeAPF\ORM\DocumentModel $documentModel = null,
         int $cacheExpiration                    = 0,
         int $cacheMode                          = YeAPF_SAVE_CACHE_FIRST
     ) {

--- a/src/database/yeapf-persistence-interface.php
+++ b/src/database/yeapf-persistence-interface.php
@@ -7,8 +7,8 @@ class PersistenceContext
     static private $redisConnection=null;
     static private $pdoConnection=null;
     public function __construct(
-        \YeAPF\Connection\DB\RedisConnection $redisConnection=null,
-        \YeAPF\Connection\DB\PDOConnection $pdoConnection=null)
+        ?\YeAPF\Connection\DB\RedisConnection $redisConnection=null,
+        ?\YeAPF\Connection\DB\PDOConnection $pdoConnection=null)
     {
         self::$redisConnection = $redisConnection;
         self::$pdoConnection = $pdoConnection;

--- a/src/database/yeapf-redis-connection.php
+++ b/src/database/yeapf-redis-connection.php
@@ -111,7 +111,7 @@ class RedisConnection extends \YeAPF\Connection\DBConnection
         return $ret;
     }
 
-    public function hset(string $name, mixed $data, int $expiration = null)
+    public function hset(string $name, mixed $data, ?int $expiration = null)
     {
         $ret = false;
         if (self::getConnected()) {
@@ -181,7 +181,7 @@ class RedisConnection extends \YeAPF\Connection\DBConnection
         return $ret;
     }
 
-    public function setKeyExpiration(string $name, int $expiration = null)
+    public function setKeyExpiration(string $name, ?int $expiration = null)
 {
     if (self::getConnected()) {
         if ($expiration !== null) {
@@ -190,7 +190,7 @@ class RedisConnection extends \YeAPF\Connection\DBConnection
     }
 }
 
-    public function setGlobalExpiration(int $expiration = null)
+    public function setGlobalExpiration(?int $expiration = null)
     {
         if (self::getConnected()) {
             if ($expiration !== null) {

--- a/src/plugins/i18n.php
+++ b/src/plugins/i18n.php
@@ -256,10 +256,10 @@ class Translator extends \YeAPF\Plugins\ServicePlugin implements \YeAPF\Plugins\
   }
 
   public function translate(
-    string $scope      = null,
-    string $targetLang = null,
-    string $tag        = null,
-    string $DOMText    = null
+    ?string $scope      = null,
+    ?string $targetLang = null,
+    ?string $tag        = null,
+    ?string $DOMText    = null
   ) {
     $ret = [];
 

--- a/src/service/yeapf-sse-service.php
+++ b/src/service/yeapf-sse-service.php
@@ -300,7 +300,7 @@ class TaggedServer extends Server
         return $ret;
     }
 
-    public function enqueueEvent(string $source, string $event, string|array|object|null $data, string $id = null, int $retry = null)
+    public function enqueueEvent(string $source, string $event, string|array|object|null $data, ?string $id = null, ?int $retry = null)
     {
         $this->grantQueue();
         SSEUniqueQueue::enqueueEvent($source, $this->clientId, $event, $data, $id, $retry);
@@ -387,7 +387,7 @@ abstract class SSEService extends \YeAPF\YeAPFConfig
         unset($this->runningServers[$fd]);
     }
 
-    public function addEvent(string $source, string $target, string $event, string|array|object|null $data, string $id = null)
+    public function addEvent(string $source, string $target, string $event, string|array|object|null $data, ?string $id = null)
     {
         try {
             $this->lock->lock();

--- a/src/yeapf-exception.php
+++ b/src/yeapf-exception.php
@@ -79,7 +79,7 @@ function handleException($message, $code, $file, $line, $trace, $isException = t
 
 class YeAPFException extends \Exception
 {
-  function __construct(string $message, int $code = YeAPF_UNDEFINED_EXCEPTION, \Exception $previous = null)
+  function __construct(string $message, int $code = YeAPF_UNDEFINED_EXCEPTION, ?\Exception $previous = null)
   {
     $hex = '';
     $from = '';


### PR DESCRIPTION
PHP 8.4 deprecou 'implicitly marking parameter $x as nullable' para `T $x = null`. Converte 20 assinaturas em 7 arquivos da lib (`?T $x = null`) — mesma semântica em runtime, elimina as deprecations que disparavam no boot (YeAPFException::__construct, SanitizedKeyData::__construct/getConstraints, RedisConnection::hset, etc.).

Exclui `src/vendor/nusoap` (terceiros) e `examples/`. Lint PHP 8.4 OK em todos os arquivos alterados; sem resíduo.

Origem: diagnóstico no ERP-DryWall (docs/issues/063).